### PR TITLE
Add animation to show/hide media player on play/pause

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,7 +7,7 @@ import type Song from './types/Song.ts';
 import MediaPlayer from './components/MediaPlayer/MediaPlayer.tsx';
 
 async function fetchDefaultSongs(page: number): Promise<Song[]> {
-  const defaultQuery = 'farm+songs+and+other+animal+songs';
+  const defaultQuery = 'red+hot';
   const response = await fetch(
     `https://itunes.apple.com/search?term=${defaultQuery}&media=music&entity=song&limit=25&offset=${
       (page - 1) * 25


### PR DESCRIPTION
This pull request adds a slide-in animation to the media player component. The animation slides the media player up from the bottom of the screen when it becomes visible, and slides it back down when it becomes hidden. This provides a more visually appealing transition when the media player is toggled.